### PR TITLE
feat: enable logging of mail contents via CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Usage: maildev [options]
 | `-o, --open`                     |                            | Open the Web GUI after startup                                                            |
 | `-v, --verbose`                  |                            |                                                                                           |
 | `--silent`                       |                            |                                                                                           |
+| `--log-mail-contents`            |                            | Log a JSON representation of each incoming mail |
 
 ## API
 

--- a/index.js
+++ b/index.js
@@ -90,6 +90,13 @@ module.exports = function (config) {
     mailserver.on('close', web.close)
   }
 
+  if (config.logMailContents) {
+    mailserver.on('new', function (mail) {
+      const mailContents = JSON.stringify(mail, null, 2)
+      logger.info(`Received the following mail contents:\n${mailContents}`)
+    })
+  }
+
   function shutdown () {
     logger.info(`Received shutdown signal, shutting down now...`)
     async.parallel([

--- a/lib/options.js
+++ b/lib/options.js
@@ -30,7 +30,8 @@ module.exports.options = [
     }
   ],
   ['-v, --verbose'],
-  ['--silent']
+  ['--silent'],
+  ['--log-mail-contents', 'Log a JSON representation of each incoming email']
 ]
 
 module.exports.appendOptions = function (program, options) {


### PR DESCRIPTION
- Declare a new CLI option, `--log-mail-contents`; when specified,
  maildev will log the JSON representation of each incoming mail,
  equivalent to the payloads emitted for 'new' events
- Implement the logging of mail contents by adding a listener for
  'new' events emitted by mailserver, and logging the events
- Add relevant documentation in README

Port of opengovsg@c483402